### PR TITLE
adding new way to configure the master for azure

### DIFF
--- a/configure-master-for-azure.yaml
+++ b/configure-master-for-azure.yaml
@@ -1,0 +1,48 @@
+---
+##
+## This is run after the OpenShift install and needs
+## create-azure-conf.yaml to be run before the install
+##
+- hosts: masters
+  gather_facts: no
+  serial: 1
+  become: yes
+  vars:
+    azure_conf_dir: /etc/origin/cloudprovider
+    azure_conf: "{{ azure_conf_dir }}/azure.conf"
+    master_conf: /etc/origin/master/master-config.yaml
+  handlers:
+  - name: restart atomic-openshift-master-api
+    systemd:
+      state: restarted
+      name: atomic-openshift-master-api
+
+  - name: restart atomic-openshift-master-controllers
+    systemd:
+      state: restarted
+      name: atomic-openshift-master-controllers
+
+  - name: insert the azure disk config into the master
+    modify_yaml:
+      dest: "{{ master_conf }}"
+      yaml_key: "{{ item.key }}"
+      yaml_value: "{{ item.value }}"
+    with_items:
+    - key: kubernetesMasterConfig.apiServerArguments.cloud-config
+      value:
+      - "{{ azure_conf }}"
+
+    - key: kubernetesMasterConfig.apiServerArguments.cloud-provider
+      value:
+      - azure
+
+    - key: kubernetesMasterConfig.controllerArguments.cloud-config
+      value:
+      - "{{ azure_conf }}"
+
+    - key: kubernetesMasterConfig.controllerArguments.cloud-provider
+      value:
+      - azure
+    notify:
+    - restart atomic-openshift-master-api
+    - restart atomic-openshift-master-controllers

--- a/configure-master-for-azure.yaml
+++ b/configure-master-for-azure.yaml
@@ -17,6 +17,7 @@
       state: restarted
       name: atomic-openshift-master-api
 
+  post_tasks:
   - name: restart atomic-openshift-master-controllers
     systemd:
       state: restarted


### PR DESCRIPTION
New script so we are backwards compatible and it doesn't create /etc/azure it uses the existing azure.conf.